### PR TITLE
feat: allow deployments with more than one server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.retry
 /hosts
+/hosts.yml
 /consul

--- a/README.md
+++ b/README.md
@@ -58,17 +58,18 @@ git clone https://github.com/consuldemocracy/installer
 cd installer
 ```
 
-Create your local `hosts` file
+Create your local `hosts.yml` file
 
 ```
-cp hosts.example hosts
+cp hosts.yml.example hosts.yml
 ```
 
-Update your local `hosts` file with the remote server's ip address
+Update your local `hosts.yml` file with the remote servers and the role of each one.
 
-```
-remote-server-ip-address (maintain other default options)
-```
+- The servers in the `rails` group will have Consul installed
+- The server in the `db` group will have Postgresql installed
+- The server in the `nfs` group will have NFS server installed (to share storage folder between Consul instances)
+- The servers in the `nfs_client` group will mount storage from the NFS server.
 
 Run the ansible playbook
 

--- a/app.yml
+++ b/app.yml
@@ -1,6 +1,6 @@
 ---
 - name: Set up web server
-  hosts: all
+  hosts: rails
   become: true
   vars:
     ansible_user: "{{ deploy_user }}"
@@ -9,7 +9,7 @@
     - nginx
 
 - name: Set up CONSUL DEMOCRACY
-  hosts: all
+  hosts: rails
   become: true
   become_user: "{{ deploy_user }}"
   vars:
@@ -25,7 +25,7 @@
     - puma
 
 - name: Post-installation tasks
-  hosts: all
+  hosts: rails
   become: true
   vars:
     ansible_user: "{{ deploy_user }}"
@@ -34,7 +34,7 @@
     - timezone
 
 - name: Install Errbit
-  hosts: all
+  hosts: rails
   become: true
   vars:
     ansible_user: "{{ deploy_user }}"
@@ -46,7 +46,7 @@
       when: errbit|bool
 
 - name: Check system
-  hosts: all
+  hosts: rails
   become: true
   vars:
     ansible_user: "{{ deploy_user }}"

--- a/consul.yml
+++ b/consul.yml
@@ -3,3 +3,5 @@
 - import_playbook: system.yml
 - import_playbook: db.yml
 - import_playbook: app.yml
+- import_playbook: nfs_server.yml
+- import_playbook: nfs_client.yml

--- a/db.yml
+++ b/db.yml
@@ -1,7 +1,5 @@
 ---
 - name: Set up PostgreSQL
-  hosts: all
-  vars:
-    ansible_user: "{{ deploy_user }}"
+  hosts: db
   roles:
     - postgresql

--- a/group_vars/all
+++ b/group_vars/all
@@ -15,6 +15,7 @@ env: production
 deploy_user: deploy
 deploy_group: wheel
 home_dir: "/home/{{ deploy_user }}"
+consul_repository: https://github.com/consuldemocracy/consuldemocracy.git
 consul_dir: "{{ home_dir }}/{{ app_name }}"
 shared_dir: "{{ consul_dir }}/shared"
 release_dir: "{{ consul_dir }}/current"
@@ -35,7 +36,7 @@ ansible_ssh_private_key_file: "~/.ssh/id_rsa"
 database_name: "{{app_name}}_{{ env }}"
 database_user: "{{ deploy_user }}"
 database_password: "{{ deploy_user }}"
-database_hostname: "localhost"
+database_hostname: "{{ storage_server | default('localhost') }}"
 
 # Puma
 # If you use Capistrano to deploy, make sure the puma_service_unit_name
@@ -70,3 +71,7 @@ errbit_domain: "errbit.{{ domain }}"
 errbit_service: "{{ app_name }}_errbit"
 errbit_user: "{{ deploy_user }}"
 errbit_group: "{{ deploy_group }}"
+
+
+# NFS
+nfs_server: "{{ storage_server }}"

--- a/hosts.yml.example
+++ b/hosts.yml.example
@@ -1,0 +1,27 @@
+---
+all:
+  vars:
+    ansible_user: root
+    storage_server: storage-server-ip-address
+  hosts:
+    pre1:
+      ansible_host: app1-server-ip-address
+    pre2:
+      ansible_host: app1-server-ip-address
+    predb:
+      ansible_host: storage-server-ip-address
+  children:
+    rails:
+      hosts:
+        pre1:
+        pre2:
+    db:
+      hosts:
+        predb:
+    nfs:
+      hosts:
+        predb:
+    nfs_client:
+      hosts:
+        pre1:
+        pre2:

--- a/nfs_client.yml
+++ b/nfs_client.yml
@@ -1,0 +1,5 @@
+---
+- name: Set up NFS client
+  hosts: nfs_client
+  roles:
+    - nfs_client

--- a/nfs_server.yml
+++ b/nfs_server.yml
@@ -1,0 +1,5 @@
+---
+- name: Set up NFS server
+  hosts: nfs
+  roles:
+    - nfs_server

--- a/roles/folder_structure/tasks/main.yml
+++ b/roles/folder_structure/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: Check that CONSUL DEMOCRACY exists
   stat:
     path: "{{ consul_dir }}"
-  register: consul_repo
 
+  register: consul_repo
 - name: Get current timestamp
   shell: "date -u +%Y%m%d%H%M%S"
   register: current_timestamp
@@ -13,8 +13,18 @@
   vars:
     first_release_dir: "{{ consul_dir }}/releases/{{ current_timestamp.stdout }}"
   block:
+    - name: Ensure correct permissions of consul directory
+      become: true
+      become_user: root
+      file:
+        path: "{{ consul_dir }}"
+        owner: "{{ deploy_user }}"
+        group: "{{ deploy_group }}"
+        mode: 0755
+        state: directory
+
     - name: Git clone CONSUL DEMOCRACY
-      shell: "git clone --mirror https://github.com/consuldemocracy/consuldemocracy.git {{ consul_dir }}/repo"
+      shell: "git clone --mirror {{ consul_repository }} {{ consul_dir }}/repo"
 
     - name: Create first release folder
       file:

--- a/roles/nfs_client/tasks/main.yml
+++ b/roles/nfs_client/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Install nfs client
+  become: true
+  apt:
+    state: latest
+    name:
+      - nfs-common
+
+- name: Mount an NFS volume
+  become: true
+  ansible.posix.mount:
+    src: "{{ nfs_server }}:/var/nfs_export/storage"
+    path: "{{ shared_dir }}/storage"
+    opts: rw,sync,hard
+    state: mounted
+    fstype: nfs

--- a/roles/nfs_server/tasks/main.yml
+++ b/roles/nfs_server/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: Install nfs server
+  become: true
+  apt:
+    state: latest
+    name:
+      - nfs-kernel-server
+
+- name: Create a shared directory
+  become: true
+  file:
+    path: /var/nfs_export/storage
+    state: directory
+    owner: 1001
+    group: 1001
+    mode: "0775"
+- name: Enable rpcbind nfslock nfs
+  become: true
+  service:
+    name: "{{ item }}"
+    enabled: true
+  with_items:
+    - rpcbind
+    - nfs-kernel-server
+- name: Set exports file
+  become: true
+  template:
+    src: "{{ playbook_dir }}/roles/nfs_server/templates/etc/exports.j2"
+    dest: /etc/exports
+    owner: root
+    group: root
+    mode: "0644"
+- name: NFS apply change configrue
+  become: true
+  shell: systemctl reload nfs-kernel-server;exportfs -a

--- a/roles/nfs_server/templates/etc/exports.j2
+++ b/roles/nfs_server/templates/etc/exports.j2
@@ -1,0 +1,3 @@
+# /etc/exports: the access control list for filesystems which may be exported
+#   to NFS clients.  See exports(5).
+/var/nfs_export/storage            *(rw,sync,no_root_squash,no_subtree_check)

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -7,6 +7,26 @@
       - postgresql-contrib
       - python3-psycopg2
 
+- name: Set PostgreSQL listens address
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/postgresql/16/main/postgresql.conf
+    regexp: '^listen_addresses '
+    insertafter: '^#listen_addresses '
+    line: "listen_addresses = '{{ database_hostname }}'"
+
+- name: Set PostgreSQL authentication
+  become: true
+  community.postgresql.postgresql_pg_hba:
+    dest: /etc/postgresql/16/main/pg_hba.conf
+    contype: host
+    users: "{{ database_user }}"
+    databases: "{{ database_name }}"
+    method: scram-sha-256
+    source: all
+    keep_comments_at_rules: true
+    comment: "Remote access allowed"
+
 - name: Start Postgres
   become: true
   service:
@@ -39,7 +59,7 @@
     - name: Add PostgreSQL extensions
       postgresql_ext:
         name: "{{ item }}"
-        db: "{{database_name}}"
+        db: "{{ database_name }}"
         schema: shared_extensions
       with_items:
         - plpgsql


### PR DESCRIPTION
This change allows installing Consuldemocracy on several servers at once, keeping one of the servers for data storage (database and files of the storage folder).

Storage folder is keep synchronized with NFS.

Using the YAML format of Ansible inventory and grouping hosts in several groups makes it easy to redistribute the services, to install all on one unique server or to discard Postgresql and NFS instalations.